### PR TITLE
Add tket queko mapping benchmark

### DIFF
--- a/games/mapping/map_queko.py
+++ b/games/mapping/map_queko.py
@@ -5,7 +5,7 @@
 import pytest
 
 from benchmarks import queko_qasm, queko_coupling
-from mapping import run_qiskit_mapper, run_tweedledum_mapper
+from mapping import run_qiskit_mapper, run_tweedledum_mapper, run_tket_mapper
 
 
 @pytest.mark.qiskit
@@ -30,3 +30,13 @@ def bench_tweedledum(benchmark, qasm) -> None:
     benchmark.algorithm = f"ApprxSatPlacer + LazyRouter"
     coupling_map = queko_coupling[benchmark.name[:5]]
     run_tweedledum_mapper(benchmark, "jit", coupling_map, qasm)
+
+
+@pytest.mark.tket
+@pytest.mark.parametrize("layout_method", ["graph", "line"])
+@pytest.mark.parametrize("qasm", queko_qasm)
+def bench_tket(benchmark, layout_method, qasm) -> None:
+    benchmark.name = qasm.name
+    benchmark.algorithm = "GraphPlacement + Routing"
+    coupling_map = queko_coupling[benchmark.name[:5]]
+    run_tket_mapper(benchmark, layout_method, coupling_map, qasm)

--- a/games/mapping/map_queko.py
+++ b/games/mapping/map_queko.py
@@ -37,6 +37,6 @@ def bench_tweedledum(benchmark, qasm) -> None:
 @pytest.mark.parametrize("qasm", queko_qasm)
 def bench_tket(benchmark, layout_method, qasm) -> None:
     benchmark.name = qasm.name
-    benchmark.algorithm = "GraphPlacement + Routing"
+    benchmark.algorithm = f"{layout_method} Placement + Routing"
     coupling_map = queko_coupling[benchmark.name[:5]]
     run_tket_mapper(benchmark, layout_method, coupling_map, qasm)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 matplotlib
 py-cpuinfo
 pytest
+tweedledum
 qiskit-terra
+pytket>1.0,<2.0
 setproctitle
 rich


### PR DESCRIPTION
This commit adds a new benchmark for testing tket's performance on the
queko benchmark suite. It runs queko with two different layout
(placement in the tket terminology) algorithms and the default
routing/mapping pass. The only place where these benchmarks are less
than ideal is that to get things to work correctly I needed to copy each
circuit in the timed function. Without this the inplace mutation and
shared references was causing the benchmarks to fail. Hopefully a better
long term solution can be found eventually.