### PR TITLE
Add config for pylint and black

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: Tests
+on:
+  push:
+    branches: [ main, 'stable/*' ]
+  pull_request:
+    branches: [ main, 'stable/*' ]
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+      - name: Pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-lint-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-lint-
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+            ${{ runner.os }}-${{ matrix.python-version }}-
+      - name: Install Deps
+        run: python -m pip install -U tox
+      - name: Run lint
+        run: tox -elint

--- a/.pylintrc
+++ b/.pylintrc
@@ -33,7 +33,7 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-allow-list=numpy, tweedledum, qiskit._accelerate
+extension-pkg-allow-list=numpy, tweedledum, qiskit._accelerate, pytket, setproctitle
 
 
 [MESSAGES CONTROL]
@@ -72,9 +72,8 @@ disable=spelling,       # way too noisy
     no-else-return,     # relax "elif" after a clause with a return
     docstring-first-line-empty, # relax docstring style
     import-outside-toplevel,
-    bad-continuation, bad-whitespace # differences of opinion with black
-
-
+    bad-continuation, bad-whitespace, # differences of opinion with black
+    missing-function-docstring
 
 
 [REPORTS]

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -2,6 +2,10 @@
 # Part of Qiskit.  This file is distributed under the Apache 2.0 License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+
+"""Benchmarks data."""
+
+
 import os
 from pathlib import Path
 

--- a/games/mapping/__init__.py
+++ b/games/mapping/__init__.py
@@ -2,6 +2,10 @@
 # Part of Red Queen Project.  This file is distributed under the MIT License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+
+"""Mapping benchmarks."""
+
+
 from tweedledum.ir import Circuit
 from tweedledum.target import Device
 from tweedledum.passes import bridge_decomp, bridge_map, jit_map, sabre_map
@@ -26,13 +30,11 @@ from qiskit.transpiler.passes import SabreSwap
 from qiskit.transpiler.passes import StochasticSwap
 
 
-def _qiskit_pass_manager(
-    layout_method, routing_method, coupling_map, seed_transpiler=1337
-):
+def _qiskit_pass_manager(layout_method, routing_method, coupling_map, seed_transpiler=1337):
     coupling_map = CouplingMap(coupling_map)
     pm = PassManager()
 
-    _swap = list()
+    _swap = []
     if routing_method == "sabre":
         _swap = [SabreSwap(coupling_map, heuristic="decay", seed=seed_transpiler)]
     elif routing_method == "stochastic":
@@ -99,9 +101,9 @@ def run_tweedledum_mapper(benchmark, routing_method, coupling_map, path):
 
 def run_tket_mapper(benchmark, layout_method, coupling_map, path):
     device = Architecture(coupling_map)
-    if layout_method == 'line':
+    if layout_method == "line":
         placement = PlacementPass(LinePlacement(device))
-    elif layout_method == 'graph':
+    elif layout_method == "graph":
         placement = PlacementPass(GraphPlacement(device))
     mapping = RoutingPass(device)
     info, mapped_circuit = benchmark(

--- a/games/mapping/map_misc.py
+++ b/games/mapping/map_misc.py
@@ -2,11 +2,14 @@
 # Part of Red Queen Project.  This file is distributed under the MIT License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
-import pytest
 
+"""Misc mapping benchmarks."""
+
+import pytest
 from qiskit.test.mock import FakeMontreal
-from benchmarks import misc_qasm
+
 from mapping import run_qiskit_mapper, run_tweedledum_mapper
+from benchmarks import misc_qasm
 
 
 backends = [FakeMontreal()]
@@ -36,6 +39,4 @@ def bench_qiskit(benchmark, layout_method, routing_method, backend, qasm) -> Non
 def bench_tweedledum(benchmark, routing_method, backend, qasm) -> None:
     benchmark.name = qasm.name
     benchmark.algorithm = routing_method
-    run_tweedledum_mapper(
-        benchmark, routing_method, backend.configuration().coupling_map, qasm
-    )
+    run_tweedledum_mapper(benchmark, routing_method, backend.configuration().coupling_map, qasm)

--- a/games/mapping/map_queko.py
+++ b/games/mapping/map_queko.py
@@ -2,10 +2,13 @@
 # Part of Red Queen Project.  This file is distributed under the MIT License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+
+"""QUEKO mapping benchmarks."""
+
 import pytest
 
-from benchmarks import queko_qasm, queko_coupling
 from mapping import run_qiskit_mapper, run_tweedledum_mapper, run_tket_mapper
+from benchmarks import queko_qasm, queko_coupling
 
 
 @pytest.mark.qiskit
@@ -16,7 +19,7 @@ def bench_qiskit(benchmark, layout_method, routing_method, qasm) -> None:
     benchmark.name = qasm.name
     benchmark.algorithm = f"{layout_method} + {routing_method}"
     # This is really annoying:
-    coupling_map = list()
+    coupling_map = []
     for pair in queko_coupling[benchmark.name[:5]]:
         coupling_map.append(pair)
         coupling_map.append(pair[::-1])
@@ -27,7 +30,7 @@ def bench_qiskit(benchmark, layout_method, routing_method, qasm) -> None:
 @pytest.mark.parametrize("qasm", queko_qasm)
 def bench_tweedledum(benchmark, qasm) -> None:
     benchmark.name = qasm.name
-    benchmark.algorithm = f"ApprxSatPlacer + LazyRouter"
+    benchmark.algorithm = "ApprxSatPlacer + LazyRouter"
     coupling_map = queko_coupling[benchmark.name[:5]]
     run_tweedledum_mapper(benchmark, "jit", coupling_map, qasm)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
+[tool.black]
+line-length = 100
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,5 @@
 markers =
     qiskit
     tweedledum
+    tket
 python_functions = bench_*

--- a/red_queen/__init__.py
+++ b/red_queen/__init__.py
@@ -2,6 +2,9 @@
 # Part of Qiskit.  This file is distributed under the Apache 2.0 License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+
+"""Red Queen root."""
+
 from .bishop import Bishop
 from .knight import Knight
 from .queen import RedQueen

--- a/red_queen/bishop.py
+++ b/red_queen/bishop.py
@@ -2,6 +2,9 @@
 # Part of Qiskit.  This file is distributed under the Apache 2.0 License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+
+"""Bishop for storing benchmark results."""
+
 import json
 import platform
 import tempfile
@@ -39,10 +42,7 @@ class Bishop:
         paths.sort(key=lambda path: (path.name), reverse=True)
         if not paths:
             return "0001"
-        try:
-            return "%04i" % (int(str(paths[0].name).split("_")[0]) + 1)
-        except ValueError:
-            raise
+        return format(int(str(paths[0].name).split("_", maxsplit=1)[0]) + 1, "04d")
 
     def __init__(self, config):
         self.store_data = config.option.store_data
@@ -55,7 +55,7 @@ class Bishop:
         self.report["benchmarks"].append(benchmark_info)
 
     def store(self):
-        if not self.report['benchmarks']:
+        if not self.report["benchmarks"]:
             return
 
         tmpfd, tmppath = tempfile.mkstemp(prefix="RedQueen_", text=True)

--- a/red_queen/fixtures.py
+++ b/red_queen/fixtures.py
@@ -2,6 +2,10 @@
 # Part of Qiskit.  This file is distributed under the Apache 2.0 License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+
+"""Benchmark fixtures."""
+
+
 import sys
 import gc
 import statistics
@@ -12,6 +16,8 @@ from timeit import default_timer
 
 
 class BenchmarkInfo:
+    """Benchmark information."""
+
     def _tool_name(self, fullname):
         index = fullname.find("[")
         name = fullname[:index]
@@ -36,9 +42,7 @@ class BenchmarkInfo:
             "tool": self.tool,
             "algorithm": self.algorithm,
             "stats": {
-                "timing": dict(
-                    (field, getattr(self, field)) for field in self._fields()
-                ),
+                "timing": dict((field, getattr(self, field)) for field in self._fields()),
                 "quality": self.quality_stats,
             },
         }
@@ -66,6 +70,8 @@ class BenchmarkInfo:
 
 
 class BenchmarkFixture:
+    """Benchmark fixture."""
+
     def __init__(self, node):
         self.info = BenchmarkInfo(node)
         # TODO: make configurable

--- a/red_queen/knight.py
+++ b/red_queen/knight.py
@@ -2,6 +2,9 @@
 # Part of Qiskit.  This file is distributed under the Apache 2.0 License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+
+"""Knight module for managing Pawns (which run benchmarks)."""
+
 from multiprocessing import Pipe
 from multiprocessing.connection import Connection
 

--- a/red_queen/pawn.py
+++ b/red_queen/pawn.py
@@ -3,7 +3,7 @@
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
 
-"""Pwan module for running benchmarks."""
+"""Pawn module for running benchmarks."""
 
 import time
 from multiprocessing import get_context

--- a/red_queen/queen.py
+++ b/red_queen/queen.py
@@ -2,6 +2,11 @@
 # Part of Qiskit.  This file is distributed under the Apache 2.0 License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+# pylint: disable=unused-argument
+
+"""Red Queen pytest plugin."""
+
+
 import pytest
 from red_queen.bishop import Bishop
 from red_queen.rook import Rook
@@ -17,6 +22,7 @@ class RedQueen:
     The queen does nothing else. She delegates to the Rook all details of how to
     run the testing (benchmarking) session.
     """
+
     def __init__(self, config):
         self.config = config
         self.bishop = Bishop(self.config)

--- a/red_queen/rook.py
+++ b/red_queen/rook.py
@@ -2,6 +2,10 @@
 # Part of Qiskit.  This file is distributed under the Apache 2.0 License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+# pylint: disable=unused-argument
+
+"""Rook module for managing test session."""
+
 import random
 from itertools import cycle
 from multiprocessing.connection import wait
@@ -33,7 +37,7 @@ class Rook:
     def __init__(self, config, bishop):
         self.config = config
         self.bishop = bishop
-        self.tr = self.config.pluginmanager.getplugin("terminalreporter")
+        self.reporter = self.config.pluginmanager.getplugin("terminalreporter")
 
         # Knights information
         self.knights = None
@@ -92,12 +96,11 @@ class Rook:
             self.channels.append(knight.pawn_start())
 
     def _set_num_jobs(self, num_jobs: int) -> None:
-        if not self.num_jobs == None:
-            assert num_jobs == self.num_jobs
+        if self.num_jobs is not None and num_jobs == self.num_jobs:
             return
         self.num_jobs = num_jobs
         self.session.testscollected = num_jobs
-        self.pending = [i for i in range(num_jobs)]
+        self.pending = list(range(num_jobs))
 
     def _assign_job(self, knight) -> None:
         """Try to assign a new job.
@@ -137,9 +140,9 @@ class Rook:
     def _knight_collection(self, knight):
         self.collecting += 1
         if self.collecting == 1:
-            self.tr.write(f"Collecting...{self.collecting}", flush=True, bold=True)
+            self.reporter.write(f"Collecting...{self.collecting}", flush=True, bold=True)
         else:
-            self.tr.rewrite(
+            self.reporter.rewrite(
                 f"Collecting...{self.collecting}", flush=True, bold=True, erase=True
             )
 
@@ -156,7 +159,7 @@ class Rook:
             if num_collected > num_selected:
                 line += f" / {num_selected} selected"
             line += "\n"
-            self.tr.rewrite(line, bold=True, erase=True)
+            self.reporter.rewrite(line, bold=True, erase=True)
         elif self.done_collecting > len(self.knights):
             # This is a new pawn
             self._assign_job(knight)

--- a/report/console_tables.py
+++ b/report/console_tables.py
@@ -2,6 +2,10 @@
 # Part of Qiskit.  This file is distributed under the Apache 2.0 License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+
+"""Module to generate a console report."""
+
+
 import argparse
 import pathlib
 from collections import defaultdict
@@ -15,8 +19,10 @@ from .loader import group_benchmarks, load_benchmarks
 
 
 class NameFormarter:
+    """Name formatter class."""
+
     def __init__(self, group_by) -> None:
-        self.group_by = list()
+        self.group_by = []
         if "name" in group_by:
             self.group_by.append("name")
         if "tool" in group_by:
@@ -24,14 +30,14 @@ class NameFormarter:
 
     def __call__(self, benchmark) -> str:
         if self.group_by == ["name"]:
-            name = f"{benchmark['tool']} ({benchmark['algorithm']})"
+            res_name = f"{benchmark['tool']} ({benchmark['algorithm']})"
         elif self.group_by == ["tool"]:
-            name = f"{benchmark['name']} ({benchmark['algorithm']})"
+            res_name = f"{benchmark['name']} ({benchmark['algorithm']})"
         elif self.group_by == ["name", "tool"]:
-            name = f"({benchmark['algorithm']})"
+            res_name = f"({benchmark['algorithm']})"
         if benchmark["storage"]:
-            name = "{} ({:.4s})".format(name, benchmark["storage"])
-        return name
+            res_name = f"{res_name} ({benchmark['storage']:.4s})"
+        return res_name
 
 
 def normalize(baseline, value):
@@ -51,7 +57,7 @@ def formatted_normalize(baseline, value):
         else:
             return " (>1000.0)"
     else:
-        return " ({:.2f})".format(norm)
+        return f" ({norm:.2f})"
 
 
 def format_entry(stats, metric, best, worst):
@@ -64,7 +70,7 @@ def format_entry(stats, metric, best, worst):
         prefix = "[green]"
         suffix = "[green]"
     norm = formatted_normalize(best[metric], stats[metric])
-    return "{}{:.4g}{}{}".format(prefix, stats[metric], norm, suffix)
+    return f"{prefix}{stats[metric]:.4g}{norm}{suffix}"
 
 
 def benchmark_table(name, benchmarks, name_format, console):
@@ -76,16 +82,12 @@ def benchmark_table(name, benchmarks, name_format, console):
     for key, _ in benchmarks[0]["stats"]["quality"].items():
         table.add_column(key)
 
-    best = dict()
-    worst = dict()
+    best = {}
+    worst = {}
     for kind in ["timing", "quality"]:
         for metric in benchmarks[0]["stats"][kind].keys():
-            worst[metric] = max(
-                [benchmark["stats"][kind][metric] for benchmark in benchmarks]
-            )
-            best[metric] = min(
-                [benchmark["stats"][kind][metric] for benchmark in benchmarks]
-            )
+            worst[metric] = max([benchmark["stats"][kind][metric] for benchmark in benchmarks])
+            best[metric] = min([benchmark["stats"][kind][metric] for benchmark in benchmarks])
 
     for benchmark in benchmarks:
         timing = benchmark["stats"]["timing"]
@@ -93,7 +95,7 @@ def benchmark_table(name, benchmarks, name_format, console):
         min_str = format_entry(timing, "min", best, worst)
         max_str = format_entry(timing, "max", best, worst)
         mean_str = format_entry(timing, "mean", best, worst)
-        quality_str = list()
+        quality_str = []
         for key, _ in quality.items():
             quality_str.append(format_entry(quality, key, best, worst))
         table.add_row(name_format(benchmark), min_str, max_str, mean_str, *quality_str)
@@ -116,16 +118,14 @@ def aggregate_results(aggregate, benchmarks, name_format):
 
     for benchmark in benchmarks:
         data = aggregate.get(benchmark["name"], defaultdict(list))
-        data["mean"].append(
-            normalize(baselines["timing"], benchmark["stats"]["timing"]["mean"])
-        )
+        data["mean"].append(normalize(baselines["timing"], benchmark["stats"]["timing"]["mean"]))
         if not skip_quality:
             for key, value in benchmark["stats"]["quality"].items():
                 data[key].append(normalize(baselines[key], value))
         aggregate[benchmark["name"]] = data
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description="Console tables reporter.")
     parser.add_argument(
         "--storage",
@@ -140,26 +140,30 @@ if __name__ == "__main__":
     groups = group_benchmarks(benchmarks, group_by="name")
     name_format = NameFormarter(group_by="name")
     console = Console()
-    aggregate = dict()
+    aggregate = {}
     for group, benchmarks in groups:
         benchmark_table(group, benchmarks, name_format, console)
         aggregate_results(aggregate, benchmarks, name_format)
 
-    table = Table(title=f"TLDR")
+    table = Table(title="TLDR")
     table.add_column("Name")
     table.add_column("Mean")
     best = defaultdict(lambda: float("inf"))
     worst = defaultdict(float)
-    for name, data in aggregate.items():
+    for row_name, data in aggregate.items():
         for stat, series in data.items():
             data[stat] = geometric_mean(series)
             best[stat] = min(best[stat], data[stat])
             worst[stat] = max(worst[stat], data[stat])
 
-    for name, data in aggregate.items():
-        stats = list()
+    for row_name, data in aggregate.items():
+        row_stats = []
         for stat, _ in data.items():
-            stats.append(format_entry(data, stat, best, worst))
-        table.add_row(name, *stats)
+            row_stats.append(format_entry(data, stat, best, worst))
+        table.add_row(row_name, *row_stats)
 
     console.print("\n", table, "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/report/loader.py
+++ b/report/loader.py
@@ -2,6 +2,9 @@
 # Part of Qiskit.  This file is distributed under the Apache 2.0 License.
 # See accompanying file /LICENSE for details.
 # ------------------------------------------------------------------------------
+
+"""Load benchmark result functions."""
+
 import json
 from collections import defaultdict
 
@@ -18,11 +21,11 @@ def load_benchmarks(dir_or_file, filter_by=None):
         paths = list(dir_or_file.glob("**/*.json"))
         paths.sort(key=lambda path: (path.name, path.parent))
         for path in paths:
-            if path.is_file() == False:
+            if not path.is_file():
                 continue
             try:
                 data = json.loads(path.read_text(encoding="utf8"))
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 print(f"Failed to load JSON file: {path}")
                 continue
             for benchmark in data["benchmarks"]:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py39,py38,py37,py310,lint
+envlist = py37,py38,py39,py310,lint
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,39 @@
+[tox]
+minversion = 2.1
+envlist = py39,py38,py37,py310,lint
+skipsdist = True
+
+[testenv]
+usedevelop = False
+install_command = pip install -U {opts} {packages}
+setenv =
+  VIRTUAL_ENV={envdir}
+  QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
+deps =
+  -r{toxinidir}/requirements.txt
+passenv = OMP_NUM_THREADS QISKIT_PARALLEL RAYON_NUM_THREADS
+commands = pytest
+
+[testenv:lint]
+envdir = .tox/lint
+deps =
+  pylint==2.13.8
+  astroid==2.11.4
+  black ~= 22.0
+  -r{toxinidir}/requirements.txt
+commands =
+  black --check {posargs} red_queen/ games/ benchmarks/ report/
+  pylint -rn -j 0 --rcfile={toxinidir}/.pylintrc red_queen/ games/ benchmarks/ report/
+
+[testenv:black]
+envdir = .tox/lint
+deps =
+  pylint==2.13.8
+  astroid==2.11.4
+  black ~= 22.0
+  -r{toxinidir}/requirements.txt
+commands = black {posargs} red_queen/ games/ benchmarks/ report/
+
+[testenv:docs]
+commands =
+  sphinx-build -b html {posargs} docs/ docs/_build/html


### PR DESCRIPTION
This commit adds configuration to run black and pylint to establish
coding style and lint checking on the red queen repository. To do this a
tox.ini is added to automate venv creation and running both pylint and
black with consistent versions. A github actions CI configuration is
also added to ensure that any future proposed changes to the repo have
black tool's styling applied and complies with the pylint rules.