### PR TITLE
Fix CI configuration for lint job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Pip cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Previously in #5 we added a CI job to enforce that lint was passing
before we merge a PR. However, that new job was setup to run with Python
3.10 but didn't properly quote the python version which led gha to treat
the Python version as a float instead of a string. This wasn't caught
because the PR was opened from a fork instead of a branch and initial CI
configurations aren't triggered on a PR from a fork. This commit fixes
this issue by quoting the python version in the yaml configuration to
ensure that CI can run.