### PR TITLE
add qiskit basis passes

### DIFF
--- a/games/basis/__init__.py
+++ b/games/basis/__init__.py
@@ -8,7 +8,7 @@
 from qiskit import QuantumCircuit
 from qiskit.transpiler.passmanager import PassManager
 
-from qiskit.transpiler.passes import BasisTranslator
+from qiskit.transpiler.passes import BasisTranslator, Decompose, Unroller, Unroll3qOrMore, UnrollCustomDefinitions
 from qiskit.circuit.library.standard_gates.equivalence_library import (
     StandardEquivalenceLibrary as std_eqlib,
 )
@@ -19,6 +19,12 @@ def _qiskit_pass_manager(basis_method, basis, seed_transpiler=1337):
 
     if basis_method == "basis_translator":
         _pass_list = [BasisTranslator(std_eqlib, basis)]
+    elif basis_method == "decompose":
+        _pass_list = [Decompose()]
+    elif basis_method == "unroll_3q_or_more":
+        _pass_list = [Unroll3qOrMore()]
+    elif basis_method == "unroll_custom_definitions":
+        _pass_list = [UnrollCustomDefinitions(std_eqlib, basis)]
     else:
         raise NotImplementedError("Basis method '{basis_method}'")
 
@@ -26,11 +32,8 @@ def _qiskit_pass_manager(basis_method, basis, seed_transpiler=1337):
     pm.append(_pass_list)
     return pm
 
-
     
 def run_qiskit_basis(benchmark, basis_method, basis, path):
     circuit = QuantumCircuit.from_qasm_file(str(path))
     pm = _qiskit_pass_manager(basis_method, basis)
     info, mapped_circuit = benchmark(pm.run, circuit)
-    info.quality_stats["cx"] = 3 * mapped_circuit.count_ops().get("swap", 0)
-

--- a/games/basis/__init__.py
+++ b/games/basis/__init__.py
@@ -1,0 +1,36 @@
+# ------------------------------------------------------------------------------
+# Part of Red Queen Project.  This file is distributed under the MIT License.
+# See accompanying file /LICENSE for details.
+# ------------------------------------------------------------------------------
+
+"""Mapping benchmarks."""
+
+from qiskit import QuantumCircuit
+from qiskit.transpiler.passmanager import PassManager
+
+from qiskit.transpiler.passes import BasisTranslator
+from qiskit.circuit.library.standard_gates.equivalence_library import (
+    StandardEquivalenceLibrary as std_eqlib,
+)
+
+
+def _qiskit_pass_manager(basis_method, basis, seed_transpiler=1337):
+    pm = PassManager()
+
+    if basis_method == "basis_translator":
+        _pass_list = [BasisTranslator(std_eqlib, basis)]
+    else:
+        raise NotImplementedError("Basis method '{basis_method}'")
+
+    # Build pass manager
+    pm.append(_pass_list)
+    return pm
+
+
+    
+def run_qiskit_basis(benchmark, basis_method, basis, path):
+    circuit = QuantumCircuit.from_qasm_file(str(path))
+    pm = _qiskit_pass_manager(basis_method, basis)
+    info, mapped_circuit = benchmark(pm.run, circuit)
+    info.quality_stats["cx"] = 3 * mapped_circuit.count_ops().get("swap", 0)
+

--- a/games/basis/__init__.py
+++ b/games/basis/__init__.py
@@ -5,10 +5,17 @@
 
 """Mapping benchmarks."""
 
+import qiskit
 from qiskit import QuantumCircuit
 from qiskit.transpiler.passmanager import PassManager
 
-from qiskit.transpiler.passes import BasisTranslator, Decompose, Unroller, Unroll3qOrMore, UnrollCustomDefinitions
+from qiskit.transpiler.passes import (
+    BasisTranslator,
+    Decompose,
+    Unroller,
+    Unroll3qOrMore,
+    UnrollCustomDefinitions,
+)
 from qiskit.circuit.library.standard_gates.equivalence_library import (
     StandardEquivalenceLibrary as std_eqlib,
 )
@@ -32,8 +39,9 @@ def _qiskit_pass_manager(basis_method, basis, seed_transpiler=1337):
     pm.append(_pass_list)
     return pm
 
-    
+
 def run_qiskit_basis(benchmark, basis_method, basis, path):
     circuit = QuantumCircuit.from_qasm_file(str(path))
     pm = _qiskit_pass_manager(basis_method, basis)
     info, mapped_circuit = benchmark(pm.run, circuit)
+    info.tool_version = qiskit.version.get_version_info()

--- a/games/basis/basis_misc.py
+++ b/games/basis/basis_misc.py
@@ -6,15 +6,17 @@
 """Misc mapping benchmarks."""
 
 import pytest
+import scipy.stats
 from basis import run_qiskit_basis
 from benchmarks import misc_qasm
+
 
 bases = [["u", "cx"],
          ["sx", "rz", "cx"],
          ]
 
 @pytest.mark.qiskit
-@pytest.mark.parametrize("basis_method", ["basis_translator"])
+@pytest.mark.parametrize("basis_method", ["basis_translator", "decompose", "unroll_3q_or_more", "unroll_custom_definitions"])
 @pytest.mark.parametrize("basis", bases)
 @pytest.mark.parametrize("qasm", misc_qasm)
 def bench_qiskit(benchmark, basis_method, basis, qasm) -> None:
@@ -26,4 +28,3 @@ def bench_qiskit(benchmark, basis_method, basis, qasm) -> None:
         basis,
         qasm,
     )
-    

--- a/games/basis/basis_misc.py
+++ b/games/basis/basis_misc.py
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------------------
+# Part of Red Queen Project.  This file is distributed under the MIT License.
+# See accompanying file /LICENSE for details.
+# ------------------------------------------------------------------------------
+
+"""Misc mapping benchmarks."""
+
+import pytest
+from basis import run_qiskit_basis
+from benchmarks import misc_qasm
+
+bases = [["u", "cx"],
+         ["sx", "rz", "cx"],
+         ]
+
+@pytest.mark.qiskit
+@pytest.mark.parametrize("basis_method", ["basis_translator"])
+@pytest.mark.parametrize("basis", bases)
+@pytest.mark.parametrize("qasm", misc_qasm)
+def bench_qiskit(benchmark, basis_method, basis, qasm) -> None:
+    benchmark.name = qasm.name
+    benchmark.algorithm = f"{basis_method}"
+    run_qiskit_basis(
+        benchmark,
+        basis_method,
+        basis,
+        qasm,
+    )
+    

--- a/games/basis/basis_misc.py
+++ b/games/basis/basis_misc.py
@@ -11,12 +11,17 @@ from basis import run_qiskit_basis
 from benchmarks import misc_qasm
 
 
-bases = [["u", "cx"],
-         ["sx", "rz", "cx"],
-         ]
+bases = [
+    ["u", "cx"],
+    ["sx", "rz", "cx"],
+]
+
 
 @pytest.mark.qiskit
-@pytest.mark.parametrize("basis_method", ["basis_translator", "decompose", "unroll_3q_or_more", "unroll_custom_definitions"])
+@pytest.mark.parametrize(
+    "basis_method",
+    ["basis_translator", "decompose", "unroll_3q_or_more", "unroll_custom_definitions"],
+)
 @pytest.mark.parametrize("basis", bases)
 @pytest.mark.parametrize("qasm", misc_qasm)
 def bench_qiskit(benchmark, basis_method, basis, qasm) -> None:

--- a/red_queen/fixtures.py
+++ b/red_queen/fixtures.py
@@ -28,6 +28,7 @@ class BenchmarkInfo:
         self._id = node._nodeid
         self.name = None
         self.tool = self._tool_name(node.name)
+        self.tool_version = "unknown"
         self.algorithm = "default"
         self._time_data = []
         self.quality_stats = {}
@@ -40,6 +41,7 @@ class BenchmarkInfo:
             "id": self._id,
             "name": self.name,
             "tool": self.tool,
+            "tool_version": self.tool_version,
             "algorithm": self.algorithm,
             "stats": {
                 "timing": dict((field, getattr(self, field)) for field in self._fields()),
@@ -118,7 +120,7 @@ class BenchmarkFixture:
             except:
                 raise
             finally:
-                #if not __debug__:
+                # if not __debug__:
                 sys.settrace(tracer)
                 if gc_enabled:
                     gc.enable()

--- a/red_queen/fixtures.py
+++ b/red_queen/fixtures.py
@@ -101,7 +101,7 @@ class BenchmarkFixture:
             if self._disable_gc:
                 gc.disable()
             tracer = sys.gettrace()
-            sys.settrace(None)
+            #sys.settrace(None)
             try:
                 if num_runs:
                     r = range(num_runs)
@@ -116,7 +116,7 @@ class BenchmarkFixture:
                     end = default_timer()
                     return end - start, result
             finally:
-                sys.settrace(tracer)
+                #sys.settrace(tracer)
                 if gc_enabled:
                     gc.enable()
 

--- a/red_queen/fixtures.py
+++ b/red_queen/fixtures.py
@@ -101,7 +101,7 @@ class BenchmarkFixture:
             if self._disable_gc:
                 gc.disable()
             tracer = sys.gettrace()
-            #sys.settrace(None)
+            sys.settrace(None)
             try:
                 if num_runs:
                     r = range(num_runs)
@@ -115,8 +115,11 @@ class BenchmarkFixture:
                     result = function_to_benchmark(*args, **kwargs)
                     end = default_timer()
                     return end - start, result
+            except:
+                raise
             finally:
-                #sys.settrace(tracer)
+                #if not __debug__:
+                sys.settrace(tracer)
                 if gc_enabled:
                     gc.enable()
 


### PR DESCRIPTION
This adds tests for qiskit basis passes. Currently it just uses circuits from `benchmarks/misc` which may not involve much translation.