### PR TITLE
Add Windows instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To run pytest on Windows, you will have to use `python -m` in order to run the
 `pytest` command. You will also need to add `-s` to your pytest call to disable 
 stdin handling.
 ```bash
-python -m pytest -s games/mapping/map_queko.py -m qiskit --store
+python -m pytest -s games/mapping/map_queko.py -m tweedledum --store
 ```
 
 The benchmark suite will consider all functions named `bench_*` in 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ You must do it using `pytest`
 ```bash
 pytest games/mapping/map_queko.py -m tweedledum --store
 ```
+
+To run pytest on Windows, you will have to use `python -m` in order to run the 
+`pytest` command. You will also need to add `-s` to your pytest call to disable 
+stdin handling.
+```bash
+python -m pytest -s games/mapping/map_queko.py -m qiskit --store
+```
+
 The benchmark suite will consider all functions named `bench_*` in 
 `games/mapping/map_queko.py`. Because we set the `-m` option, only the the ones
 marked with `tweedledum` will be run. (We could easy do the same for `qiskit`).


### PR DESCRIPTION
For Windows users to be able to run the pytest command, the instructions are a bit different. I have added a line that explains the differences. This can be helpful for any future users that work on windows.