### PR TITLE
Fix deprecated FakeMontreal import path

### DIFF
--- a/games/mapping/map_misc.py
+++ b/games/mapping/map_misc.py
@@ -6,7 +6,7 @@
 """Misc mapping benchmarks."""
 
 import pytest
-from qiskit.test.mock import FakeMontreal
+from qiskit.providers.fake_provider import FakeMontreal
 
 from mapping import run_qiskit_mapper, run_tweedledum_mapper
 from benchmarks import misc_qasm


### PR DESCRIPTION
In qiskit-terra 0.21.0 the qiskit.test.mock path was deprecated and the
code was migrated to live in qiskit.providers.fake_provider. However,
while the old path still exists it works by re-exporting the new path
from the old path. Pylint is able to realize this and is throwing an
error about the FakeMontreal name not being found in the
qiskit.test.mock module. To fix this lint failure this commit just
updates the import to use the new path to avoid this issue. We would
have to make this change anyway after the deprecation cycle is finished
and qiskit.test.mock is removed.