### PR TITLE
Fix hidden shift benchmark

### DIFF
--- a/red_queen/games/applications/hidden_shift.py
+++ b/red_queen/games/applications/hidden_shift.py
@@ -107,7 +107,7 @@ def hs_circuit(num_qubits, secret_string):
 @pytest.mark.qiskit
 @pytest.mark.parametrize("optimization_level", [0, 1, 2, 3])
 @pytest.mark.parametrize("backend", backends)
-def bench_qiskit_hs(benchmark, optimization_level, backend, method):
+def bench_qiskit_hs(benchmark, optimization_level, backend):
     """benchmarking for hidden_shift"""
     shots = 33333
     expected_counts = {SECRET_STRING: shots}


### PR DESCRIPTION
In the recently merged hidden shift benchmark, which was added as part
of #20, there was n oversight that slipped through as part of some code
review refactoring. An extra parameterized argument which was removed in
an earlier revision of the PR was left on the function signature. This
causes the benchmark to fail to execute because pytest doesn't know how
to populate that parameter as it no longer exists. This commit corrects
this oversight and removes the leftover argument. Hopefully in the
future we'll have #29 which will catch these easy to miss issues
pre-merge and block us from merging broken code.