### PR TITLE
Fixed oversight in changed-benchmark action

### DIFF
--- a/.github/actions/changed-benchmark/action.yml
+++ b/.github/actions/changed-benchmark/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: tj-actions/changed-files@v24.1
       with:
         files: |
-          ${{ inputs.path }}
+          ${{ inputs.path }}/*.py
     - name: Test applications
       run: |
         if [[ "${{steps.changed-benchmarks.outputs.all_changed_and_modified_files}}" != "" ]]; then


### PR DESCRIPTION
Forgot to add "/*.py" suffix to only accept python files.