### PR TITLE
Added sweeps for number of qubits

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -47,7 +47,12 @@ def pytest_addoption(parser):
         dest="store_data",
         help="",
     )
-
+    group.addoption(
+	"--num_qubits",
+        default="Linear:10:100:50",
+        help="",
+    )
+ 
 
 @pytest.mark.trylast
 def pytest_configure(config):

--- a/red_queen/games/applications/run_bv.py
+++ b/red_queen/games/applications/run_bv.py
@@ -4,7 +4,6 @@
 # ------------------------------------------------------------------------------
 
 """Benchmark Bernstein Vazirani circuits."""
-
 import os
 
 import pytest
@@ -13,14 +12,35 @@ from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 
 from red_queen.games.applications import backends, run_qiskit_circuit
 
+import random
+
+import numpy
 
 QASM_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "qasm")
-SECRET_STRING = "110011"
 
 
+@pytest.fixture
+def get_num_qubits(request):
+    return request.config.getoption("--num_qubits")
+
+
+def generate_num_qubits(get_num_qubits):
+    user_params = requests.get(get_num_qubits)
+    user_params = user_params.split(":")
+    if user_params[0] == "linear":
+        sweep_list = numpy.linspace(int(user_params[1]), int(user_params[2]), int(user_params[3]))
+        sweep_list = [int(i) for i in sweep_list]
+    if user_params[0] == "log":
+        sweep_list = numpy.logspace(int(user_params[1]), int(user_params[2]), int(user_params[3]))
+        sweep_list = [int(i) for i in sweep_list]
+    for i in sweep_list:
+        num_qubits = i
+        SECRET_STRING = bin(random.getrandbits(i - 1))[2:]
+
+
+@pytest.mark.parametrize("num_qubits", sweep_list)
 def build_bv_circuit(secret_string, mid_circuit_measure=False):
     input_size = len(secret_string)
-    num_qubits = input_size + 1
     if not mid_circuit_measure:
         qr = QuantumRegister(num_qubits)
         cr = ClassicalRegister(input_size)

--- a/red_queen/games/applications/run_ft.py
+++ b/red_queen/games/applications/run_ft.py
@@ -23,12 +23,31 @@ from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 
 DIRECTORY = "qasm"
 QASM_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), DIRECTORY)
-SECRET_STRING = "11111111"
+
+
+@pytest.fixture
+def get_num_qubits(request):
+    return request.config.getoption("--num_qubits")
+
+
+def generate_num_qubits(get_num_qubits):
+    user_params = requests.get(get_num_qubits)
+    user_params = user_params.split(":")
+    if user_params[0] == "linear":
+        sweep_list = np.linspace(int(user_params[1]), int(user_params[2]), int(user_params[3]))
+        sweep_list = [int(i) for i in sweep_list]
+    if user_params[0] == "log":
+        sweep_list = np.logspace(int(user_params[1]), int(user_params[2]), int(user_params[3]))
+        sweep_list = [int(i) for i in sweep_list]
+    for i in sweep_list:
+        num_qubits = i
+        SECRET_STRING = bin(random.getrandbits(i - 1))[2:]
 
 
 """ Generates Quantum Fourier Transform circuit using QFT and Inverse QFT"""
 
 
+@pytest.mark.parametrize("num_qubits", sweep_list)
 def generate_ft_circuit_1(binary):
     qubits = QuantumRegister(len(binary))
     bits = ClassicalRegister(len(binary))


### PR DESCRIPTION
Added parameter `--num_qubits` which allows users to specify either a linear or logarithmic sweep for the number of qubits in `run_ft.py` and `run_bv.py` based on user specifications. 


