### PR TITLE
Pin tox version used in CI to <4.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U tox
+        run: python -m pip install -U 'tox<4'
       - name: Run lint
         run: tox -elint
   benchmark:


### PR DESCRIPTION
The most recent tox release, 4.0.0, is a major rewrite of the internals of tox and several things behave quite differently. This new release is causing CI jobs to fail as something in incompatible with our tox configuration (likely because it's using wheel builds instead of sdists). This commit pins the tox version we're using in CI to unblock things until we can update the tox configuration to be compatible with both the new and old versions of tox.